### PR TITLE
dependencies: Use >= for numba and river

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository= "https://github.com/NorskRegnesentral/streamchange"
 python = "^3.8"
 pandas = "^1.3"
 numpy = "^1.19"
-numba = "^0.56"
+numba = ">=0.56"
 river = "^0.14"
 optuna = "^3.1.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.8"
 pandas = "^1.3"
 numpy = "^1.19"
 numba = ">=0.56"
-river = "^0.14"
+river = ">=0.14"
 optuna = "^3.1.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This is required for Python 3.11 compatibility, which is only available in numba 0.57 and later.

References #2